### PR TITLE
Bump files with dotnet-file sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,13 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: ⚙ dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+
       - name: ✓ ensure format
-        run: |
-          dotnet tool update -g dotnet-format --version 5.0.*
-          dotnet restore
-          dotnet format --check -v:diag
+        run: dotnet format --verify-no-changes -v:diag --exclude ~/.nuget
 
   build:
     name: build-${{ matrix.os }}
@@ -43,13 +45,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [windows-latest, ubuntu-latest, macOS-latest]
     steps:
       - name: 🤘 checkout
         uses: actions/checkout@v2
         with: 
           submodules: recursive
           fetch-depth: 0
+
+      - name: ⚙ dotnet
+        uses: actions/setup-dotnet@v1
+        if: matrix.os != 'windows-latest'
+        with:
+          dotnet-version: '6.0.x'
 
       - name: 🙏 build
         run: dotnet build -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"
@@ -61,34 +69,7 @@ jobs:
           echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
 
       - name: 🧪 test
-        shell: bash --noprofile --norc {0}
-        env:
-          LC_ALL: en_US.utf8
-        run: |
-          [ -f .bash_profile ] && source .bash_profile
-          counter=0
-          exitcode=0
-          reset="\e[0m"
-          warn="\e[0;33m"
-          while [ $counter -lt 6 ]
-          do
-              if [ $filter ]
-              then
-                  echo -e "${warn}Retry $counter for $filter ${reset}"
-              fi
-              # run test and forward output also to a file in addition to stdout (tee command)
-              dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m --filter=$filter | tee ./output.log
-              # capture dotnet test exit status, different from tee
-              exitcode=${PIPESTATUS[0]}
-              if [ $exitcode == 0 ]
-              then
-                  exit 0
-              fi
-              # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
-              filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)\w*' | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
-              ((counter++))
-          done
-          exit $exitcode
+        uses: ./.github/workflows/test
 
       - name: 📦 pack
         run: dotnet pack -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,9 +24,14 @@ jobs:
           ref: main
           token: ${{ env.GH_TOKEN }}
 
+      - name: ⚙ ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.3
+
       - name: ⚙ changelog
         run: |
-          sudo gem install github_changelog_generator 
+          gem install github_changelog_generator 
           github_changelog_generator --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: 🚀 changelog

--- a/.github/workflows/dotnet-file.yml
+++ b/.github/workflows/dotnet-file.yml
@@ -53,7 +53,7 @@ jobs:
           branch: dotnet-file-sync
           delete-branch: true
           labels: dependencies
-          commit-message: Bump files with dotnet-file sync
+          commit-message: ⬆️ Bump files with dotnet-file sync
           
             ${{ env.CHANGES }}
           title: "Bump files with dotnet-file sync"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,12 @@ jobs:
         with: 
           submodules: recursive
           fetch-depth: 0
-          
+
+      - name: ⚙ dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+
       - name: 🙏 build
         run: dotnet build -m:1 -p:version=${GITHUB_REF#refs/*/v}
 
@@ -31,34 +36,7 @@ jobs:
           echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
 
       - name: 🧪 test
-        shell: bash --noprofile --norc {0}
-        env:
-          LC_ALL: en_US.utf8
-        run: |
-          [ -f .bash_profile ] && source .bash_profile
-          counter=0
-          exitcode=0
-          reset="\e[0m"
-          warn="\e[0;33m"
-          while [ $counter -lt 6 ]
-          do
-              if [ $filter ]
-              then
-                  echo -e "${warn}Retry $counter for $filter ${reset}"
-              fi
-              # run test and forward output also to a file in addition to stdout (tee command)
-              dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m --filter=$filter | tee ./output.log
-              # capture dotnet test exit status, different from tee
-              exitcode=${PIPESTATUS[0]}
-              if [ $exitcode == 0 ]
-              then
-                  exit 0
-              fi
-              # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
-              filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)\w*' | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
-              ((counter++))
-          done
-          exit $exitcode
+        uses: ./.github/workflows/test
 
       - name: 📦 pack
         run: dotnet pack -m:1 -p:version=${GITHUB_REF#refs/*/v}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -20,16 +20,21 @@ jobs:
       - name: 🏷 since
         run: echo "SINCE_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))" >> $GITHUB_ENV
 
+      - name: ⚙ ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.3
+
       - name: ⚙ changelog
         if: env.SINCE_TAG != ''
         run: |
-          sudo gem install github_changelog_generator 
+          gem install github_changelog_generator 
           github_changelog_generator --since-tag ${{ env.SINCE_TAG }} --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: ⚙ changelog
         if: env.SINCE_TAG == ''
         run: |
-          sudo gem install github_changelog_generator 
+          gem install github_changelog_generator 
           github_changelog_generator --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: 🖉 release

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -1,0 +1,34 @@
+name: test
+description: runs dotnet tests with retry
+runs:
+  using: "composite"
+  steps:
+    - name: 🧪 test
+      shell: bash --noprofile --norc {0}
+      env:
+        LC_ALL: en_US.utf8
+      run: |
+        [ -f .bash_profile ] && source .bash_profile
+        counter=0
+        exitcode=0
+        reset="\e[0m"
+        warn="\e[0;33m"
+        while [ $counter -lt 6 ]
+        do
+            if [ $filter ]
+            then
+                echo -e "${warn}Retry $counter for $filter ${reset}"
+            fi
+            # run test and forward output also to a file in addition to stdout (tee command)
+            dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m --filter=$filter | tee ./output.log
+            # capture dotnet test exit status, different from tee
+            exitcode=${PIPESTATUS[0]}
+            if [ $exitcode == 0 ]
+            then
+                exit 0
+            fi
+            # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
+            filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)\w*' | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
+            ((counter++))
+        done
+        exit $exitcode

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ TestResults
 *.cache
 *.binlog
 *.zip
+__azurite*.*
+__*__
 
 .nuget
 *.lock.json

--- a/.netconfig
+++ b/.netconfig
@@ -49,33 +49,33 @@
 	weak
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
-	sha = 964caa363fe9cd8ef01c8a5d8e3fd07d1aed35ae
-	etag = ef5ed75b1e23292dd7af196a11f04760aa5ad4a3f374095395da9abc2de3f24f
+	sha = bbf637b2a565073a89783c9eb4ebd9c460823fe4
+	etag = 6b9139f22428851c8d7329973f3d92802d25e70a5e0c1b24604c23db991ac8e2
 	weak
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml
-	sha = b7ce2bedba3fe467b8bc252c372cd36bbde259a5
-	etag = 99c02f817f1a2b6ffaec4f7c4cd1c60e6bfae966174568f8027a4a2f42a00e69
+	sha = be8f625e4cf5c2c572c7e56ba6dc4c4935ab0c00
+	etag = 202803313c2792cb09d9cb8041fe4b39e550e26c90971a57b92534c599a596a7
 	weak
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml
-	sha = 084aa7c36ee1c262ea2f9e83931068366a7b4312
-	etag = 501f8bf58287fdd7467701342f7251a015bc29664b494e7d81a71c0c55bee61f
+	sha = 2a39a426f66402e47c80818f92748a1bfd7d736c
+	etag = c424e4f9159bd5d4ccb3b65646a65eed5ad153f57111e3b56900ebce10194f3f
 	weak
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
-	sha = 964caa363fe9cd8ef01c8a5d8e3fd07d1aed35ae
-	etag = d6369e92c55eb78322ff39d26fc4ef1996b691a8ce05392395ab393e14ddb940
+	sha = 7ebebbdbab67d9d895a29b3d2b3f82a62a7d8c4e
+	etag = 242bd273906e0cbef773b5a0696f6dccf304d044a659b68e75ede5b1f5ea94fe
 	weak
 [file ".github/workflows/release-notes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/release-notes.yml
-	sha = b7ce2bedba3fe467b8bc252c372cd36bbde259a5
-	etag = f9e85892ecefdc98584d9a90c3b29e63e910f161b8761a51eaeb94dfa9bd3e4f
+	sha = be8f625e4cf5c2c572c7e56ba6dc4c4935ab0c00
+	etag = d1de9cb9c403ed8632d22d4cc153ae63b075266b9ce638b9ac73fd47dd2bccc1
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	sha = a9f9d3f5db6dd0714f52da61e35ab233fd0a1642
-	etag = e6ba96dc8c185a4e9c64f7c2c8003ef86e8f73624865ff7f6ae955aad55a164e
+	sha = 978c71c6afd095eaba35097fd7deed44fa09aa91
+	etag = 2b49512f81b6cb44c4ee398975c0edf41bfa4137857b59770805fa7c5e49e94b
 	weak
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
@@ -109,13 +109,13 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = e2606657b68d2980cc3cae181c59baa3d847ab75
-	etag = a44fa4e71022b1c5f9684ec65815f69b47d51d0289e58bd9396606bd88e4244a
+	sha = 2fea462dc563923800a7efad24a52aa0541a8864
+	etag = 819e24ed16c1257f3c6ea3c728e1507020bacf32aeb63f5dd56f9a5cb2652275
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = bfe0f2a2a668878931f43b7280f0406a2171ff0c
-	etag = 46287392cb21e28595b1ea658236b8afa15f985c9f75dc08ed85e81a2c465755
+	sha = 4f57ffe1d48addf16641934e7b1e47ef70204e6e
+	etag = 87c4dff4b44072c6825b451957af6d920616d77c50152a7d99719151c3d24639
 	weak
 [file "src/kzu.snk"]
 	url = https://github.com/devlooped/oss/blob/main/src/kzu.snk
@@ -151,4 +151,14 @@
 	url = https://github.com/devlooped/oss/blob/main/.github/.github_changelog_generator
 	sha = b7ce2bedba3fe467b8bc252c372cd36bbde259a5
 	etag = 28145d505ce95b57628ab368bb12744300d5f539d3651c346e3c0c3f772ffa7b
+	weak
+[file ".github/workflows/test/action.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/workflows/test/action.yml
+	sha = 3b9f317fc4f3edb926b26c4e4db9773a5f95ebca
+	etag = cf89aeff5c66fd3c0d0aaa655b527d66f5e823413c7a6788a62542e93d344576
+	weak
+[file "src/nuget.config"]
+	url = https://github.com/devlooped/oss/blob/main/src/nuget.config
+	sha = 7d0ccab53c166b87b971040f25de06570821f8ac
+	etag = 0ef58051c4db505e16b39954b27ab9e7a903647998b959e0924634d5f01824dd
 	weak

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,6 +39,9 @@
     <!-- Use Directory.Packages.props if possible. NOTE: other MSBuild SDKs (i.e. NoTargets/Traversal) do not support central packages -->
     <ManagePackageVersionsCentrally Condition="Exists('$(MSBuildThisFileDirectory)Directory.Packages.props') AND ('$(MSBuildProjectExtension)' == '.csproj' OR '$(MSBuildProjectExtension)' == '.vbproj')">true</ManagePackageVersionsCentrally>
     <RestoreSources>https://api.nuget.org/v3/index.json;https://pkg.kzu.io/index.json;$(RestoreSources)</RestoreSources>
+
+    <!-- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] -->
+    <GeneratePathProperty>true</GeneratePathProperty>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">
@@ -80,6 +83,9 @@
     
     <!-- Preserve transitively copied content in VS: https://github.com/dotnet/msbuild/issues/1054#issuecomment-847959047 -->
     <MSBuildCopyContentTransitively>true</MSBuildCopyContentTransitively>
+    
+    <!-- Global tools should run on whatever latest runtime is installed. See https://docs.microsoft.com/en-us/dotnet/core/versions/selection#framework-dependent-apps-roll-forward -->
+    <RollForward>LatestMinor</RollForward>
   </PropertyGroup>
 
   <PropertyGroup Label="StrongName" Condition="Exists('$(MSBuildThisFileDirectory)kzu.snk')">
@@ -124,6 +130,8 @@
   </PropertyGroup>
 
   <ItemGroup Label="ThisAssembly.Project">
+    <ProjectProperty Include="CI" />
+  
     <ProjectProperty Include="Version" />
     <ProjectProperty Include="VersionPrefix" />
     <ProjectProperty Include="VersionSuffix" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -109,8 +109,11 @@
 
   <ItemGroup>
     <!-- Make these available via ThisAssembly.Project -->
+    <ProjectProperty Include="RepositoryBranch" />
     <ProjectProperty Include="RepositorySha" />
     <ProjectProperty Include="RepositoryCommit" />
+    <ProjectProperty Include="RepositoryRoot" />
+    <ProjectProperty Include="RepositoryUrl" />
   </ItemGroup>
 
   <!-- Make sure the source control info is available before calling source generators -->
@@ -129,6 +132,15 @@
       <RepositorySha Condition="'$(RepositorySha)' == ''">$(SourceRevisionId.Substring(0, 9))</RepositorySha>
       <!-- This allows the commit label added to the InformationalVersion to be the short sha instead :) -->
       <SourceRevisionId>$(RepositorySha)</SourceRevisionId>
+    </PropertyGroup>
+
+    <!-- Add SourceRoot as a project property too -->
+    <ItemGroup>
+      <_GitSourceRoot Include="@(SourceRoot -> WithMetadataValue('SourceControl', 'git'))" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <RepositoryRoot>@(_GitSourceRoot)</RepositoryRoot>
     </PropertyGroup>
 
   </Target>

--- a/src/dotnet-evergreen/dotnet-evergreen.csproj
+++ b/src/dotnet-evergreen/dotnet-evergreen.csproj
@@ -6,8 +6,7 @@
     </Description>
 
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' == 'true'">net5.0</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <AssemblyName>evergreen</AssemblyName>
     <RootNamespace>Devlooped</RootNamespace>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <config>
+      <add key="signatureValidationMode" value="accept" />
+    </config>
+    <trustedSigners>
+      <author name="Microsoft">
+        <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+      </author>
+      <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
+        <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint=" CF7AC17AD047ECD5FDC36822031B12D4EF078B6F2B4C5E6BA41F8FF2CF4BAD67" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="C474CE76007D02394E0DA5E4DE7C14C680F9E282013CFEF653EF5DB71FDF61F8" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+      </repository>
+    </trustedSigners>
+</configuration>


### PR DESCRIPTION
# devlooped/oss

- Reuse test with retries definition by using a composite action https://github.com/devlooped/oss/commit/3b9f317
- Avoid nuget errors for nuget repository signature validation https://github.com/devlooped/oss/commit/7d0ccab
- Now that .NET6 is LTS, ensure it's installed https://github.com/devlooped/oss/commit/7ebebbd
- Ensure ruby v3 is installed for changelog generation https://github.com/devlooped/oss/commit/be8f625
- Switch to windows-latest agent which is now .NET6 https://github.com/devlooped/oss/commit/445239b
- Ignore nuget-provided files for formatting https://github.com/devlooped/oss/commit/bbf637b
- Ignore azurite files https://github.com/devlooped/oss/commit/829faad
- Add azurite hidden folders too https://github.com/devlooped/oss/commit/978c71c
- Global tools should run on whatever latest runtime is installed. https://github.com/devlooped/oss/commit/b65c8f1
- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] https://github.com/devlooped/oss/commit/cc6922f
- Add CI as a project property https://github.com/devlooped/oss/commit/2fea462
- Add RepositoryBranch as a ThisAssembly.Project property https://github.com/devlooped/oss/commit/83d7378
- Add RepositoryRoot property from source control information https://github.com/devlooped/oss/commit/f9763d3
- Add RepositoryUrl as project property, if available https://github.com/devlooped/oss/commit/4f57ffe
- Add icon prefix to match dependabot https://github.com/devlooped/oss/commit/2a39a42