### PR TITLE
Drop net6 since net5 can run on net6 runtime

### DIFF
--- a/src/dotnet-evergreen/dotnet-evergreen.csproj
+++ b/src/dotnet-evergreen/dotnet-evergreen.csproj
@@ -6,7 +6,7 @@
     </Description>
 
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <TargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">net6.0</TargetFramework>
 
     <AssemblyName>evergreen</AssemblyName>


### PR DESCRIPTION
NOTE: inside the IDE, we'll use .net6 so as not to require
another SDK to be installed by VS.

Fixes #28